### PR TITLE
stateful configs for instances in a mig

### DIFF
--- a/modules/stateful_config/README.md
+++ b/modules/stateful_config/README.md
@@ -11,11 +11,11 @@
 | mig\_name | Managed instance group name to attach instances to. | `string` | n/a | yes |
 | minimal\_action | The minimal action to perform on the instance during an update. | `string` | `"NONE"` | no |
 | most\_disruptive\_allowed\_action | The most disruptive action to perform on the instance during an update. | `string` | `"REPLACE"` | no |
-| name\_prefix | Name prefix for the instances | `string` | n/a | yes |
-| num\_instances | Number of stateful instances. | `number` | `1` | no |
+| names | Instance names. | `list(string)` | n/a | yes |
 | project\_id | The GCP project ID | `string` | n/a | yes |
 | region | Region where the instances should be created. | `string` | n/a | yes |
-| stateful\_disks | List of maps of stateful disks. | <pre>list(object({<br>    device_name = string<br>    source      = string<br>    delete_rule = string<br>    mode        = string<br>  }))<br></pre> | `[]` | no |
+| stateful\_disks | Map of maps of stateful disks. | `any` | `{}` | no |
+| stateful\_metadata | Map of maps of stateful metadata. | `any` | `{}` | no |
 
 ## Outputs
 

--- a/modules/stateful_config/README.md
+++ b/modules/stateful_config/README.md
@@ -1,0 +1,25 @@
+## Providers
+
+| Name | Version |
+|------|---------|
+| google-beta | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| mig\_name | Managed instance group name to attach instances to. | `string` | n/a | yes |
+| minimal\_action | The minimal action to perform on the instance during an update. | `string` | `"NONE"` | no |
+| most\_disruptive\_allowed\_action | The most disruptive action to perform on the instance during an update. | `string` | `"REPLACE"` | no |
+| name\_prefix | Name prefix for the instances | `string` | n/a | yes |
+| num\_instances | Number of stateful instances. | `number` | `1` | no |
+| project\_id | The GCP project ID | `string` | n/a | yes |
+| region | Region where the instances should be created. | `string` | n/a | yes |
+| stateful\_disks | List of maps of stateful disks. | <pre>list(object({<br>    device_name = string<br>    source      = string<br>    delete_rule = string<br>    mode        = string<br>  }))<br></pre> | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| instance\_names | Names of stateful instances |
+

--- a/modules/stateful_config/main.tf
+++ b/modules/stateful_config/main.tf
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#####################
+# Per Instance Config
+#####################
+
+resource "google_compute_region_per_instance_config" "this" {
+  count    = var.num_instances
+  provider = google-beta
+
+  project                        = var.project_id
+  region                         = var.region
+  region_instance_group_manager  = var.mig_name
+  minimal_action                 = var.minimal_action
+  most_disruptive_allowed_action = var.most_disruptive_allowed_action
+
+  name = "${var.name_prefix}-${count.index}"
+
+  preserved_state {
+    dynamic "disk" {
+      for_each = var.stateful_disks
+      content {
+        device_name = lookup(disk.value, "device_name", null)
+        source      = lookup(disk.value, "source", null)
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      preserved_state
+    ]
+  }
+}

--- a/modules/stateful_config/main.tf
+++ b/modules/stateful_config/main.tf
@@ -19,7 +19,7 @@
 #####################
 
 resource "google_compute_region_per_instance_config" "this" {
-  count    = var.num_instances
+  count    = length(var.names)
   provider = google-beta
 
   project                        = var.project_id
@@ -28,11 +28,12 @@ resource "google_compute_region_per_instance_config" "this" {
   minimal_action                 = var.minimal_action
   most_disruptive_allowed_action = var.most_disruptive_allowed_action
 
-  name = "${var.name_prefix}-${count.index}"
+  name = element(var.names, count.index)
 
   preserved_state {
+    metadata = lookup(var.stateful_metadata, element(var.names, count.index), {})
     dynamic "disk" {
-      for_each = var.stateful_disks
+      for_each = lookup(var.stateful_disks, element(var.names, count.index), {})
       content {
         device_name = lookup(disk.value, "device_name", null)
         source      = lookup(disk.value, "source", null)

--- a/modules/stateful_config/outputs.tf
+++ b/modules/stateful_config/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,7 @@
  * limitations under the License.
  */
 
-// This file was automatically generated from a template in ./autogen
-
-output "self_link" {
-  description = "Self-link of managed instance group"
-  value       = google_compute_region_instance_group_manager.mig.self_link
-}
-
-output "instance_group" {
-  description = "Instance-group url of managed instance group"
-  value       = google_compute_region_instance_group_manager.mig.instance_group
-}
-
-output "name" {
-  description = "Managed instance group name"
-  value       = google_compute_region_instance_group_manager.mig.name
+output "instance_names" {
+  description = "Names of stateful instances"
+  value       = google_compute_region_per_instance_config.this.*.name
 }

--- a/modules/stateful_config/variables.tf
+++ b/modules/stateful_config/variables.tf
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "The GCP project ID"
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Name prefix for the instances"
+}
+
+variable "region" {
+  type        = string
+  description = "Region where the instances should be created."
+}
+
+variable "num_instances" {
+  type        = number
+  description = "Number of stateful instances."
+  default     = 1
+}
+
+variable "mig_name" {
+  type        = string
+  description = "Managed instance group name to attach instances to."
+}
+
+variable "stateful_disks" {
+  description = "List of maps of stateful disks."
+  type = list(object({
+    device_name = string
+    source      = string
+    delete_rule = string
+    mode        = string
+  }))
+  default = []
+}
+
+variable "minimal_action" {
+  type        = string
+  description = "The minimal action to perform on the instance during an update."
+  default     = "NONE"
+}
+
+variable "most_disruptive_allowed_action" {
+  type        = string
+  description = "The most disruptive action to perform on the instance during an update."
+  default     = "REPLACE"
+}

--- a/modules/stateful_config/variables.tf
+++ b/modules/stateful_config/variables.tf
@@ -19,20 +19,14 @@ variable "project_id" {
   description = "The GCP project ID"
 }
 
-variable "name_prefix" {
-  type        = string
-  description = "Name prefix for the instances"
+variable "names" {
+  description = "Instance names."
+  type        = list(string)
 }
 
 variable "region" {
   type        = string
   description = "Region where the instances should be created."
-}
-
-variable "num_instances" {
-  type        = number
-  description = "Number of stateful instances."
-  default     = 1
 }
 
 variable "mig_name" {
@@ -41,14 +35,15 @@ variable "mig_name" {
 }
 
 variable "stateful_disks" {
-  description = "List of maps of stateful disks."
-  type = list(object({
-    device_name = string
-    source      = string
-    delete_rule = string
-    mode        = string
-  }))
-  default = []
+  description = "Map of maps of stateful disks."
+  type        = any
+  default     = {}
+}
+
+variable "stateful_metadata" {
+  description = "Map of maps of stateful metadata."
+  type        = any
+  default     = {}
 }
 
 variable "minimal_action" {

--- a/modules/stateful_config/versions.tf
+++ b/modules/stateful_config/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 
-// This file was automatically generated from a template in ./autogen
-
-output "self_link" {
-  description = "Self-link of managed instance group"
-  value       = google_compute_region_instance_group_manager.mig.self_link
-}
-
-output "instance_group" {
-  description = "Instance-group url of managed instance group"
-  value       = google_compute_region_instance_group_manager.mig.instance_group
-}
-
-output "name" {
-  description = "Managed instance group name"
-  value       = google_compute_region_instance_group_manager.mig.name
+terraform {
+  required_version = "~> 0.12.6"
+  required_providers {
+    google = ">= 2.7, <4.0"
+  }
 }


### PR DESCRIPTION
Example Terragrunt:
```
terraform {
  source = "/Users/rhadley/code/terraform-modules/terraform-google-vm/modules/stateful_config"
}

# Include all settings from the root terragrunt.hcl file
include {
  path = find_in_parent_folders()
}

locals {
  default_yaml_path = find_in_parent_folders("empty.yaml")
  common            = yamldecode(file(find_in_parent_folders("common.yaml", local.default_yaml_path)))
  regional          = yamldecode(file(find_in_parent_folders("regional.yaml", local.default_yaml_path)))
}

inputs = {
  project_id = local.common.service_project_id
  mig_name   = "example-mig"
  names      = ["instance-1", "instance-2"]
  stateful_disks = {
    instance-1 = [{
      device_name = "disk1"
      source      = "disk1.self_link"
      delete_rule = "NEVER"
      mode        = "READ_WRITE"
      },
      {
        device_name = "disk2"
        source      = "disk2.self_link"
        delete_rule = "NEVER"
        mode        = "READ_WRITE"
    }]
    instance-2 = [{
      device_name = "disk3"
      source      = "disk3.self_link"
      delete_rule = "NEVER"
      mode        = "READ_WRITE"
      },
      {
        device_name = "disk4"
        source      = "disk4.self_link"
        delete_rule = "NEVER"
        mode        = "READ_WRITE"
    }]
  }
  stateful_metadata = {
    instance-1 = {
      metadata1 = "instance-1-metadata-1"
      metadata2 = "instance-1-metadata-2"
    }
    instance-2 = {
      metadata1 = "instance-2-metadata-1"
      metadata2 = "instance-2-metadata-2"
    }
  }
}
```

example plan:
```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_compute_region_per_instance_config.this[0] will be created
  + resource "google_compute_region_per_instance_config" "this" {
      + id                             = (known after apply)
      + minimal_action                 = "NONE"
      + most_disruptive_allowed_action = "REPLACE"
      + name                           = "instance-1"
      + project                        = "staging-service-1-a6cc977c"
      + region                         = "us-east4"
      + region_instance_group_manager  = "example-mig"

      + preserved_state {
          + metadata = {
              + "metadata1" = "instance-1-metadata-1"
              + "metadata2" = "instance-1-metadata-2"
            }

          + disk {
              + delete_rule = "NEVER"
              + device_name = "disk1"
              + mode        = "READ_WRITE"
              + source      = "disk1.self_link"
            }
          + disk {
              + delete_rule = "NEVER"
              + device_name = "disk2"
              + mode        = "READ_WRITE"
              + source      = "disk2.self_link"
            }
        }
    }

  # google_compute_region_per_instance_config.this[1] will be created
  + resource "google_compute_region_per_instance_config" "this" {
      + id                             = (known after apply)
      + minimal_action                 = "NONE"
      + most_disruptive_allowed_action = "REPLACE"
      + name                           = "instance-2"
      + project                        = "staging-service-1-a6cc977c"
      + region                         = "us-east4"
      + region_instance_group_manager  = "example-mig"

      + preserved_state {
          + metadata = {
              + "metadata1" = "instance-2-metadata-1"
              + "metadata2" = "instance-2-metadata-2"
            }

          + disk {
              + delete_rule = "NEVER"
              + device_name = "disk3"
              + mode        = "READ_WRITE"
              + source      = "disk3.self_link"
            }
          + disk {
              + delete_rule = "NEVER"
              + device_name = "disk4"
              + mode        = "READ_WRITE"
              + source      = "disk4.self_link"
            }
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------
```