### PR TITLE
change count to for_each

### DIFF
--- a/RECURLY_CHANGELOG.md
+++ b/RECURLY_CHANGELOG.md
@@ -1,3 +1,5 @@
+## [v2.0.9_recurly] 2025-08-12
+- replace count in VM IAM with for_each
 ## [v2.0.8_recurly] 2024-09-26
 - Remove time limit in JIT MySQL access
 

--- a/modules/mysql_vm_iam/main.tf
+++ b/modules/mysql_vm_iam/main.tf
@@ -17,9 +17,9 @@ resource "google_compute_instance_iam_member" "osadmin" {
 }
 
 resource "google_secret_manager_secret_iam_member" "secrets" {
-  count     = length(var.secrets)
+  for_each   = toset(var.secrets)
   project   = var.project_id
-  secret_id = var.secrets[count.index]
+  secret_id = each.value
   role      = "roles/secretmanager.secretAccessor"
   member    = var.service_account
 }


### PR DESCRIPTION
Count is causing IAM member to be destroyed when input is multiple values coming from a dependency map. `Index is out of range for count`. 