### PR TITLE
Remove redundant project_id from IAM grant

### DIFF
--- a/RECURLY_CHANGELOG.md
+++ b/RECURLY_CHANGELOG.md
@@ -1,5 +1,9 @@
+## [v2.0.10_recurly] 2025-08-26
+- Remove the project_id from the mysql_vm_iam secretAccessor IAM grant
+
 ## [v2.0.9_recurly] 2025-08-12
 - replace count in VM IAM with for_each
+
 ## [v2.0.8_recurly] 2024-09-26
 - Remove time limit in JIT MySQL access
 

--- a/modules/mysql_vm_iam/main.tf
+++ b/modules/mysql_vm_iam/main.tf
@@ -18,7 +18,6 @@ resource "google_compute_instance_iam_member" "osadmin" {
 
 resource "google_secret_manager_secret_iam_member" "secrets" {
   for_each   = toset(var.secrets)
-  project   = var.project_id
   secret_id = each.value
   role      = "roles/secretmanager.secretAccessor"
   member    = var.service_account


### PR DESCRIPTION
The project_id is now inferred from the secret_id dependency, making it unnecessary to explicitly define it. This resolves an issue in terragrunt where the resource was being replaced on every run